### PR TITLE
Add Prettier with tslint plugin and precommit hook

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,8 @@ node_js:
 env:
   global:
   # Please get your own free key if you want to test yourself
-  - BROWSERSTACK_USERNAME: dtktestaccount1
-  - BROWSERSTACK_ACCESS_KEY: mG2qbEFJCZY2qLsM7yfx
+  - BROWSERSTACK_USERNAME: dylanschiemann2
+  - BROWSERSTACK_ACCESS_KEY: 2upt88qsxsqqeukQvecu
   - SAUCE_USERNAME: dojo2-ts-ci
   - SAUCE_ACCESS_KEY: e92610e3-834e-4bec-a3b5-6f7b9d874601
 install:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,7 @@
+# Thank You
+
+We very much welcome contributions to Dojo 2.
+
+Because we have so many repositories that are part of Dojo 2, we have located our [Contributing Guidelines](https://github.com/dojo/meta/blob/master/CONTRIBUTING.md) in our [Dojo 2 Meta Repository](https://github.com/dojo/meta#readme).
+
+Look forward to working with you on Dojo 2!!!

--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -1,0 +1,28 @@
+<!--
+Thank you for contributing to Dojo 2.
+
+Our issue tracker is for bugs for Dojo 2.
+
+Please make sure you have read our Contributing Guidelines
+available at: https://github.com/dojo/meta/blob/master/CONTRIBUTING.md
+
+For general questions and discussion, join us on Gitter.im at: https://gitter.im/dojo/dojo2
+-->
+
+**Bug**
+**Enhancement**
+<!-- delete as appropriate -->
+
+<!-- Summary of enhancement or bug-->
+
+**Code**
+
+<!-- a self contained example of code that demonstrates the issue -->
+
+**Expected behavior:**
+
+<!-- What did you expect to happen -->
+
+**Actual behavior:**
+
+<!-- What was the actual behavior? -->

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,13 @@
+**Type:** bug
+**Type:** feature
+<!-- delete one -->
+
+The following has been addressed in the PR:
+
+* [ ] There is a related issue
+* [ ] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
+* [ ] Unit or Functional tests are included in the PR
+
+**Description:**
+
+Resolves #???

--- a/README.md
+++ b/README.md
@@ -34,8 +34,17 @@ For example, if you have widgets which live in the folder: `node_modules/@dojo/w
 
 ## How do I contribute?
 
-We appreciate your interest!  Please see the [Dojo 2 Meta Repository](https://github.com/dojo/meta#readme) for the
-Contributing Guidelines and Style Guide.
+We appreciate your interest!  Please see the [Dojo 2 Meta Repository](https://github.com/dojo/meta#readme) for the Contributing Guidelines.
+
+### Code Style
+
+This repository uses [`prettier`](https://prettier.io/) for code styling rules and formatting. A pre-commit hook is installed automatically and configured to run `prettier` against all staged files as per the configuration in the projects `package.json`.
+
+An additional npm script to run `prettier` (with write set to `true`) against all `src` and `test` project files is available by running:
+
+```bash
+npm run prettier
+```
 
 ## Testing
 

--- a/package.json
+++ b/package.json
@@ -23,8 +23,11 @@
     "url": "https://github.com/dojo/cli-create-theme.git"
   },
   "scripts": {
-    "test": "grunt test",
-    "build": "./node_modules/.bin/grunt release --pre-release-tag=rc --dry-run --skip-checks --initial --force"
+    "build": "./node_modules/.bin/grunt release --pre-release-tag=rc --dry-run --skip-checks --initial --force",
+    "prepublish": "grunt peerDepInstall",
+    "precommit": "lint-staged",
+    "prettier": "prettier --write 'src/**/*.ts' 'tests/**/*.ts'",
+    "test": "grunt test"
   },
   "devDependencies": {
     "@dojo/loader": "beta1",
@@ -40,9 +43,15 @@
     "codecov.io": "0.1.6",
     "grunt": "~1.0.1",
     "grunt-dojo2": "latest",
+    "grunt-tslint": "5.0.1",
+    "husky": "0.14.3",
     "intern": "~4.1.0",
+    "lint-staged": "6.0.0",
     "mockery": "^2.1.0",
+    "prettier": "1.9.2",
     "sinon": "^4.1.2",
+    "tslint": "5.2.0",
+    "tslint-plugin-prettier": "1.3.0",
     "typescript": "~2.4.2"
   },
   "dependencies": {
@@ -52,5 +61,19 @@
     "inquirer": "^4.0.1",
     "mkdirp": "^0.5.1",
     "pkg-dir": "^2.0.0"
+  },
+  "lint-staged": {
+    "*.{ts,tsx}": [
+      "prettier --write",
+      "git add"
+    ]
+  },
+  "prettier": {
+    "singleQuote": true,
+    "tabWidth": 4,
+    "useTabs": true,
+    "parser": "typescript",
+    "printWidth": 120,
+    "arrowParens": "always"
   }
 }

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "sinon": "^4.1.2",
     "tslint": "5.2.0",
     "tslint-plugin-prettier": "1.3.0",
-    "typescript": "~2.4.2"
+    "typescript": "~2.6.1"
   },
   "dependencies": {
     "camelcase": "^4.1.0",

--- a/src/WidgetDataInterface.ts
+++ b/src/WidgetDataInterface.ts
@@ -1,4 +1,4 @@
 export default interface WidgetDataInterface {
 	themeKey: string;
 	fileName: string;
-}
+};

--- a/src/createThemeFile.ts
+++ b/src/createThemeFile.ts
@@ -12,10 +12,10 @@ async function createThemeFile({
 	CSSModuleExtension,
 	renderFiles
 }: {
-	themesDirectory: string,
-	themedWidgets: WidgetDataInterface[],
-	CSSModuleExtension: string,
-	renderFiles: any
+	themesDirectory: string;
+	themedWidgets: WidgetDataInterface[];
+	CSSModuleExtension: string;
+	renderFiles: any;
 }): Promise<void> {
 	const mainThemeFileName = `theme.ts`;
 	const fullThemeFilePath = join(process.cwd(), themesDirectory, mainThemeFileName);
@@ -25,9 +25,7 @@ async function createThemeFile({
 		return;
 	}
 
-	const CSSModulesData = themedWidgets.map(({
-		themeKey, fileName
-	}) => {
+	const CSSModulesData = themedWidgets.map(({ themeKey, fileName }) => {
 		const CSSModulePath = `${themeKey}/${fileName}${CSSModuleExtension}`;
 		const themeKeyVariable = camelcase(fileName);
 
@@ -40,12 +38,17 @@ async function createThemeFile({
 
 	const src = join(packagePath, 'templates', 'src', `${mainThemeFileName}.ejs`);
 
-	renderFiles([{
-		src,
-		dest: fullThemeFilePath
-	}], {
-		CSSModules: CSSModulesData
-	});
+	renderFiles(
+		[
+			{
+				src,
+				dest: fullThemeFilePath
+			}
+		],
+		{
+			CSSModules: CSSModulesData
+		}
+	);
 }
 
 export default createThemeFile;

--- a/src/createThemeFile.ts
+++ b/src/createThemeFile.ts
@@ -1,4 +1,4 @@
-import { join, basename } from 'path';
+import { join } from 'path';
 import * as camelcase from 'camelcase';
 import * as fs from 'fs-extra';
 import WidgetDataInterface from './WidgetDataInterface';

--- a/src/main.ts
+++ b/src/main.ts
@@ -13,4 +13,5 @@ const command = {
 		};
 	}
 };
+
 export default command;

--- a/src/main.ts
+++ b/src/main.ts
@@ -7,11 +7,9 @@ const command = {
 	eject() {
 		return {
 			npm: {
-				devDependencies: {
-				}
+				devDependencies: {}
 			},
-			copy: {
-			}
+			copy: {}
 		};
 	}
 };

--- a/src/questions.ts
+++ b/src/questions.ts
@@ -1,29 +1,34 @@
 import * as inquirer from 'inquirer';
 import { basename } from 'path';
 
-const packageQuestions: inquirer.Question[] = [{
-	type: 'input',
-	name: 'package',
-	message: 'What Package to do you want to theme?'
-}, {
-	type: 'confirm',
-	name: 'askAgain',
-	message: 'Any more?',
-	default: true
-}];
+const packageQuestions: inquirer.Question[] = [
+	{
+		type: 'input',
+		name: 'package',
+		message: 'What Package to do you want to theme?'
+	},
+	{
+		type: 'confirm',
+		name: 'askAgain',
+		message: 'Any more?',
+		default: true
+	}
+];
 
 function getFileQuestions(packageName: string, files: string[], cssDataFileExtension: string): inquirer.Question[] {
-	return [{
-		type: 'checkbox',
-		message: `Which of the ${packageName} theme files would you like to scaffold?`,
-		name: 'files',
-		choices: files.map((name: string): inquirer.ChoiceType => {
-			return {
-				name: basename(name).split(cssDataFileExtension)[ 0 ],
-				value: name
-			};
-		})
-	}];
+	return [
+		{
+			type: 'checkbox',
+			message: `Which of the ${packageName} theme files would you like to scaffold?`,
+			name: 'files',
+			choices: files.map((name: string): inquirer.ChoiceType => {
+				return {
+					name: basename(name).split(cssDataFileExtension)[0],
+					value: name
+				};
+			})
+		}
+	];
 }
 
 async function askForPackageNames(packageQuestions: inquirer.Question[], packages: any[] = []): Promise<string[]> {
@@ -42,9 +47,4 @@ async function askForDesiredFiles(fileQuestions: inquirer.Question[]): Promise<s
 	return files;
 }
 
-export {
-	packageQuestions,
-	getFileQuestions,
-	askForPackageNames,
-	askForDesiredFiles
-}
+export { packageQuestions, getFileQuestions, askForPackageNames, askForDesiredFiles };

--- a/src/run.ts
+++ b/src/run.ts
@@ -9,12 +9,7 @@ import createThemeFile from './createThemeFile';
 import convertSelectorsToCSS from './convertSelectorsToCSS';
 import flattenArray from './flattenArray';
 
-import {
-	packageQuestions,
-	getFileQuestions,
-	askForDesiredFiles,
-	askForPackageNames
-} from './questions';
+import { packageQuestions, getFileQuestions, askForDesiredFiles, askForPackageNames } from './questions';
 
 async function run(helper: Helper) {
 	const CSSModuleExtension = '.m.css';
@@ -37,7 +32,7 @@ async function run(helper: Helper) {
 		const selectedWidgets = await askForDesiredFiles(fileQuestions);
 
 		const themedWidgets = selectedWidgets.map((selectedWidget: string): WidgetDataInterface => {
-			const [ fileName ] = basename(selectedWidget).split(cssDataFileExtension);
+			const [fileName] = basename(selectedWidget).split(cssDataFileExtension);
 			const themeKey = join(packageName, fileName);
 			const fullWidgetPath = join(process.cwd(), selectedWidget);
 			const selectors = Object.keys(require(fullWidgetPath));

--- a/tests/unit/main.ts
+++ b/tests/unit/main.ts
@@ -1,7 +1,7 @@
 import * as mockery from 'mockery';
 import * as sinon from 'sinon';
 
-const { beforeEach, afterEach, describe, it } = intern.getInterface('bdd');
+const { describe, it } = intern.getInterface('bdd');
 const { assert } = intern.getPlugin('chai');
 
 describe('main', () => {

--- a/tests/unit/main.ts
+++ b/tests/unit/main.ts
@@ -9,16 +9,18 @@ describe('main', () => {
 		const sandbox = sinon.sandbox.create();
 		const promptStub: sinon.SinonStub = sandbox.stub();
 
-		promptStub.returns(Promise.resolve({
-			package: 'some-package'
-		}));
+		promptStub.returns(
+			Promise.resolve({
+				package: 'some-package'
+			})
+		);
 
-		mockery.enable({warnOnUnregistered: false, useCleanCache: true});
+		mockery.enable({ warnOnUnregistered: false, useCleanCache: true });
 		mockery.registerMock('inquirer', {
 			prompt: promptStub
 		});
 
-		const {run} = (require('../../src/main')).default;
+		const { run } = require('../../src/main').default;
 
 		try {
 			await run();
@@ -33,29 +35,37 @@ describe('main', () => {
 	});
 
 	it('creates css modules and a theme file', async () => {
-		mockery.enable({warnOnUnregistered: false});
+		mockery.enable({ warnOnUnregistered: false });
 		mockery.registerAllowable('../../src/main', true);
 
 		const sandbox = sinon.sandbox.create();
 		const promptStub: sinon.SinonStub = sandbox.stub();
 
-		promptStub.onCall(0).returns(Promise.resolve({
-			package: 'some-package-1',
-			askAgain: true
-		}));
+		promptStub.onCall(0).returns(
+			Promise.resolve({
+				package: 'some-package-1',
+				askAgain: true
+			})
+		);
 
-		promptStub.onCall(1).returns(Promise.resolve({
-			package: 'some-package-2',
-			askAgain: false
-		}));
+		promptStub.onCall(1).returns(
+			Promise.resolve({
+				package: 'some-package-2',
+				askAgain: false
+			})
+		);
 
-		promptStub.onCall(2).returns(Promise.resolve({
-			files: ['some-file-1', 'some-file-2', 'some-file-3']
-		}));
+		promptStub.onCall(2).returns(
+			Promise.resolve({
+				files: ['some-file-1', 'some-file-2', 'some-file-3']
+			})
+		);
 
-		promptStub.onCall(3).returns(Promise.resolve({
-			files: ['some-file-9']
-		}));
+		promptStub.onCall(3).returns(
+			Promise.resolve({
+				files: ['some-file-9']
+			})
+		);
 
 		mockery.registerMock('inquirer', {
 			prompt: promptStub
@@ -107,21 +117,15 @@ describe('main', () => {
 
 		const globbySyncStub: sinon.SinonStub = sandbox.stub();
 
-		globbySyncStub.onCall(0).returns([
-			'file-1.m.css.js',
-			'file-2.m.css.js',
-			'file-3.m.css.js'
-		]);
+		globbySyncStub.onCall(0).returns(['file-1.m.css.js', 'file-2.m.css.js', 'file-3.m.css.js']);
 
-		globbySyncStub.onCall(1).returns([
-			'file-9.m.css.js'
-		]);
+		globbySyncStub.onCall(1).returns(['file-9.m.css.js']);
 
 		mockery.registerMock('globby', {
 			sync: globbySyncStub
 		});
 
-		const {run} = (require('../../src/main')).default;
+		const { run } = require('../../src/main').default;
 
 		await run({
 			command: {
@@ -131,16 +135,19 @@ describe('main', () => {
 
 		assert.equal(promptStub.callCount, 4, 'The user was prompted the correct amount of times');
 
-		const packageQuestion = [{
-			type: 'input',
-			name: 'package',
-			message: 'What Package to do you want to theme?'
-		}, {
-			default: true,
-			message: 'Any more?',
-			name: 'askAgain',
-			type: 'confirm'
-		}];
+		const packageQuestion = [
+			{
+				type: 'input',
+				name: 'package',
+				message: 'What Package to do you want to theme?'
+			},
+			{
+				default: true,
+				message: 'Any more?',
+				name: 'askAgain',
+				type: 'confirm'
+			}
+		];
 
 		assert.deepEqual(promptStub.firstCall.args[0], packageQuestion);
 		assert.deepEqual(promptStub.secondCall.args[0], packageQuestion);
@@ -160,9 +167,12 @@ describe('main', () => {
 			type: 'checkbox',
 			message: 'Which of the some-package-2 theme files would you like to scaffold?',
 			name: 'files',
-			choices: [{
-				name: 'file-9', value: 'file-9.m.css.js'
-			}]
+			choices: [
+				{
+					name: 'file-9',
+					value: 'file-9.m.css.js'
+				}
+			]
 		});
 
 		assert.equal(mkdirpStub.callCount, 4, 'mkdir was called once per widget');
@@ -197,23 +207,29 @@ describe('main', () => {
 		const [[srcAndDest], templateData] = renderFilesStub.firstCall.args;
 
 		const expectedTemplateData = {
-			CSSModules: [{
-				path: 'some-package-1/some-file-1/some-file-1.m.css',
-				themeKeyVariable: 'someFile1',
-				themeKey: 'some-package-1/some-file-1'
-			}, {
-				path: 'some-package-1/some-file-2/some-file-2.m.css',
-				themeKeyVariable: 'someFile2',
-				themeKey: 'some-package-1/some-file-2'
-			}, {
-				path: 'some-package-1/some-file-3/some-file-3.m.css',
-				themeKeyVariable: 'someFile3',
-				themeKey: 'some-package-1/some-file-3'
-			}, {
-				path: 'some-package-2/some-file-9/some-file-9.m.css',
-				themeKey: 'some-package-2/some-file-9',
-				themeKeyVariable: 'someFile9'
-			}]};
+			CSSModules: [
+				{
+					path: 'some-package-1/some-file-1/some-file-1.m.css',
+					themeKeyVariable: 'someFile1',
+					themeKey: 'some-package-1/some-file-1'
+				},
+				{
+					path: 'some-package-1/some-file-2/some-file-2.m.css',
+					themeKeyVariable: 'someFile2',
+					themeKey: 'some-package-1/some-file-2'
+				},
+				{
+					path: 'some-package-1/some-file-3/some-file-3.m.css',
+					themeKeyVariable: 'someFile3',
+					themeKey: 'some-package-1/some-file-3'
+				},
+				{
+					path: 'some-package-2/some-file-9/some-file-9.m.css',
+					themeKey: 'some-package-2/some-file-9',
+					themeKeyVariable: 'someFile9'
+				}
+			]
+		};
 
 		assert.deepEqual(templateData, expectedTemplateData);
 
@@ -224,8 +240,14 @@ describe('main', () => {
 
 		assert.isTrue(existsSyncStub.calledAfter(promptStub), 'fs exists was called after the user was prompted');
 		assert.isTrue(globbySyncStub.calledAfter(existsSyncStub), 'A glob was matched after exists sync');
-		assert.isTrue(mkdirpStub.calledAfter(globbySyncStub), 'Directory for css module is created after scanning for CSS modules');
-		assert.isTrue(writeFileSyncStub.calledAfter(mkdirpStub), 'CSS module file is written after the directory is created');
+		assert.isTrue(
+			mkdirpStub.calledAfter(globbySyncStub),
+			'Directory for css module is created after scanning for CSS modules'
+		);
+		assert.isTrue(
+			writeFileSyncStub.calledAfter(mkdirpStub),
+			'CSS module file is written after the directory is created'
+		);
 		assert.isTrue(renderFilesStub.calledAfter(writeFileSyncStub), 'Theme file is written after the CSS modules');
 
 		sandbox.restore();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
 		"experimentalDecorators": true,
 		"module": "umd",
 		"moduleResolution": "node",
+		"noUnusedLocals": true,
 		"outDir": "_build/",
 		"removeComments": false,
 		"sourceMap": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
 	"compilerOptions": {
-		"declaration": true,
+		"declaration": false,
 		"experimentalDecorators": true,
 		"module": "umd",
 		"moduleResolution": "node",

--- a/tslint.json
+++ b/tslint.json
@@ -1,5 +1,7 @@
 {
+	"rulesDirectory": ["tslint-plugin-prettier"],
 	"rules": {
+		"prettier": true,
 		"align": false,
 		"arrow-parens": true,
 		"ban": [],
@@ -36,9 +38,7 @@
 		"no-var-requires": false,
 		"object-literal-sort-keys": false,
 		"one-line": [ true, "check-open-brace", "check-whitespace" ],
-		"quotemark": [ true, "single" ],
 		"radix": true,
-		"semicolon": [ true, "always" ],
 		"trailing-comma": [ true, {
 			"multiline": "never",
 			"singleline": "never"
@@ -58,7 +58,6 @@
 			"property-declaration": "onespace",
 			"variable-declaration": "onespace"
 		} ],
-		"variable-name": [ true, "check-format", "allow-leading-underscore", "ban-keywords", "allow-pascal-case" ],
-		"whitespace": [ true, "check-branch", "check-decl", "check-operator", "check-module", "check-separator", "check-type", "check-typecast" ]
+		"variable-name": [ true, "check-format", "allow-leading-underscore", "ban-keywords", "allow-pascal-case" ]
 	}
 }


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [ ] Unit or Functional tests are included in the PR

**Description:**

Adds support for `Prettier` to for code style rules and formatting. Include precommit hook that runs prettier on all `.ts` files and an npm script that runs prettier against the codebase.

Related to https://github.com/dojo/meta/issues/206