### PR TITLE
Add `name` argument to create theme command

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1,9 +1,10 @@
-import run from './run';
+import run, { CreateThemeArgs } from './run';
+import register from './register';
 import { Command } from '@dojo/interfaces/cli';
 
-const command: Command = {
+const command: Command<CreateThemeArgs> = {
 	description: 'Generate theme files from widgets',
-	register() {},
+	register,
 	run
 };
 

--- a/src/register.ts
+++ b/src/register.ts
@@ -1,0 +1,11 @@
+import { OptionsHelper } from '@dojo/interfaces/cli';
+
+export default function(options: OptionsHelper): void {
+	options('n', {
+		alias: 'name',
+		describe: 'The name of your theme',
+		demand: true,
+		requiresArg: true,
+		type: 'string'
+	});
+}

--- a/src/run.ts
+++ b/src/run.ts
@@ -10,9 +10,14 @@ import convertSelectorsToCSS from './convertSelectorsToCSS';
 
 import { packageQuestions, getFileQuestions, askForDesiredFiles, askForPackageNames } from './questions';
 
-async function run(helper: Helper) {
+export interface CreateThemeArgs {
+	name: string;
+}
+
+async function run(helper: Helper, args: CreateThemeArgs) {
+	const themeName = args.name;
 	const CSSModuleExtension = '.m.css';
-	const themesDirectory = 'src/themes';
+	const themesDirectory = `src/themes/${themeName}`;
 	const packageNames = await askForPackageNames(packageQuestions);
 	const allWidgets = [];
 

--- a/tests/unit/all.ts
+++ b/tests/unit/all.ts
@@ -2,3 +2,4 @@ import './main';
 import './questions';
 import './convertSelectorsToCSS';
 import './createThemeFile';
+import './register';

--- a/tests/unit/main.ts
+++ b/tests/unit/main.ts
@@ -41,7 +41,7 @@ describe('The main runner', () => {
 		let errorMessage = '';
 
 		try {
-			await run();
+			await run({}, { name: 'testName' });
 		} catch (err) {
 			errorMessage = err;
 		}
@@ -83,7 +83,7 @@ describe('The main runner', () => {
 		let errorMessage = '';
 
 		try {
-			await run();
+			await run({}, { name: 'testName' });
 		} catch (err) {
 			errorMessage = err;
 		}
@@ -140,15 +140,20 @@ describe('The main runner', () => {
 
 		const run = require('../../src/run').default;
 
-		await run({
-			command: {
-				renderFiles: () => {}
+		await run(
+			{
+				command: {
+					renderFiles: () => {}
+				}
+			},
+			{
+				name: 'testName'
 			}
-		});
+		);
 
 		assert.equal(mkdirpSyncStub.callCount, 2);
-		assert.deepEqual(mkdirpSyncStub.firstCall.args, ['src/themes/theme-key-1']);
-		assert.deepEqual(mkdirpSyncStub.secondCall.args, ['src/themes/theme-key-2']);
+		assert.deepEqual(mkdirpSyncStub.firstCall.args, ['src/themes/testName/theme-key-1']);
+		assert.deepEqual(mkdirpSyncStub.secondCall.args, ['src/themes/testName/theme-key-2']);
 
 		assert.equal(writeFileSyncStub.callCount, 2);
 		assert.deepEqual(writeFileSyncStub.firstCall.args, ['new/file/path-1', 'css file contents']);
@@ -200,16 +205,21 @@ describe('The main runner', () => {
 
 		const run = require('../../src/run').default;
 
-		await run({
-			command: {
-				renderFiles: 'render files mock'
+		await run(
+			{
+				command: {
+					renderFiles: 'render files mock'
+				}
+			},
+			{
+				name: 'testName'
 			}
-		});
+		);
 
 		assert.deepEqual(createThemeFileStub.firstCall.args, [
 			{
 				renderFiles: 'render files mock',
-				themesDirectory: 'src/themes',
+				themesDirectory: 'src/themes/testName',
 				themedWidgets: [{ themeKey: 'theme-key-1', fileName: 'basename return string' }],
 				CSSModuleExtension: '.m.css'
 			}

--- a/tests/unit/register.ts
+++ b/tests/unit/register.ts
@@ -1,0 +1,36 @@
+const { describe, it, beforeEach, afterEach } = intern.getInterface('bdd');
+const { assert } = intern.getPlugin('chai');
+
+import register from './../../src/register';
+import * as sinon from 'sinon';
+
+let sandbox: sinon.SinonSandbox;
+
+describe('register', () => {
+	beforeEach(() => {
+		sandbox = sinon.sandbox.create();
+	});
+
+	afterEach(() => {
+		sandbox.restore();
+	});
+
+	it('Should add a yargs option for name', () => {
+		const options = sandbox.stub();
+		register(options);
+		assert.isTrue(options.calledOnce);
+		assert.isTrue(options.firstCall.calledWithMatch('n', { alias: 'name' }));
+	});
+
+	it('Should demand the name option', () => {
+		const options = sandbox.stub();
+		register(options);
+		assert.isTrue(options.firstCall.calledWithMatch('n', { demand: true }));
+	});
+
+	it('Should require a value for the name option', () => {
+		const options = sandbox.stub();
+		register(options);
+		assert.isTrue(options.firstCall.calledWithMatch('n', { requiresArg: true }));
+	});
+});


### PR DESCRIPTION
**Type:** feature
<!-- delete one -->

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

Adds a name argument to the `create theme` command.

Resolves #21
