### PR TITLE
Fix paths in generated theme file for windows

### DIFF
--- a/src/createThemeFile.ts
+++ b/src/createThemeFile.ts
@@ -30,6 +30,7 @@ function createThemeFile({
 	}
 
 	const CSSModulesData = themedWidgets.map(({ themeKey, fileName }) => {
+		themeKey = themeKey.split(/[\\]+/).join('/');
 		const CSSModulePath = `${themeKey}/${fileName}${CSSModuleExtension}`;
 		const themeKeyVariable = camelcase(fileName);
 

--- a/tests/unit/main.ts
+++ b/tests/unit/main.ts
@@ -1,5 +1,6 @@
 import * as mockery from 'mockery';
 import * as sinon from 'sinon';
+import { join } from 'path';
 
 const { describe, it, beforeEach, afterEach } = intern.getInterface('bdd');
 const { assert } = intern.getPlugin('chai');
@@ -46,7 +47,10 @@ describe('The main runner', () => {
 			errorMessage = err;
 		}
 
-		assert.equal(errorMessage, 'Error: This package path does not exist: node_modules/some-package/theme');
+		assert.equal(
+			errorMessage,
+			'Error: This package path does not exist: ' + join('node_modules', 'some-package', 'theme')
+		);
 	});
 
 	it('errors if no widgets selections are made', async () => {


### PR DESCRIPTION
**Type:** bug
<!-- delete one -->

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**
The join function in path detects the platform and if it is windows, it changes to using backslash `\` instead of forward slash `/`. Typescript expects forward slashes `/` regardless of platform. To correct this, the themeKey needs to be switched to forward slash `/` prior to use in the template.

The `errors if the package cannot be found` unit test needed to be modified to run properly on windows. The error message produced had backslashes '\' in the path, but the unit test expected the path to always have forward slashes `/`. Using the join function here instead of a static string resolves this issue, allowing the unit test to succeed on windows and mac/linux.

Resolves #35 
